### PR TITLE
Add WarpPerspectiveWithParams function in imgproc

### DIFF
--- a/imgproc.cpp
+++ b/imgproc.cpp
@@ -501,6 +501,13 @@ void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize) {
     cv::warpPerspective(*src, *dst, *m, sz);
 }
 
+void WarpPerspectiveWithParams(Mat src, Mat dst, Mat m, Size dsize, int flags, int borderMode
+                            /*, Scalar borderValue*/) {
+    cv::Size sz(dsize.width, dsize.height);
+    //cv::Scalar c = cv::Scalar(borderValue.val1, borderValue.val2, borderValue.val3, borderValue.val4);
+    cv::warpPerspective(*src, *dst, *m, sz, flags, borderMode/*, c*/);
+}
+
 void Watershed(Mat image, Mat markers) {
     cv::watershed(*image, *markers);
 }

--- a/imgproc.go
+++ b/imgproc.go
@@ -1661,6 +1661,18 @@ func WarpPerspective(src Mat, dst *Mat, m Mat, sz image.Point) {
 	C.WarpPerspective(src.p, dst.p, m.p, pSize)
 }
 
+// WarpPerspectiveWithParams applies a perspective transformation to an image.
+//
+// For further details, please see:
+// https://docs.opencv.org/master/da/d54/group__imgproc__transform.html#gaf73673a7e8e18ec6963e3774e6a94b87
+func WarpPerspectiveWithParams(src Mat, dst *Mat, m Mat, sz image.Point, flags InterpolationFlags, borderType BorderType) {
+	pSize := C.struct_Size{
+		width:  C.int(sz.X),
+		height: C.int(sz.Y),
+	}
+	C.WarpPerspectiveWithParams(src.p, dst.p, m.p, pSize, C.int(flags), C.int(borderType))
+}
+
 // Watershed performs a marker-based image segmentation using the watershed algorithm.
 //
 // For further details, please see:

--- a/imgproc.h
+++ b/imgproc.h
@@ -104,6 +104,7 @@ void WarpAffine(Mat src, Mat dst, Mat rot_mat, Size dsize);
 void WarpAffineWithParams(Mat src, Mat dst, Mat rot_mat, Size dsize, int flags, int borderMode,
                           Scalar borderValue);
 void WarpPerspective(Mat src, Mat dst, Mat m, Size dsize);
+void WarpPerspectiveWithParams(Mat src, Mat dst, Mat m, Size dsize, int flags, int borderMode/*, Scalar borderValue*/);
 void Watershed(Mat image, Mat markers);
 void ApplyColorMap(Mat src, Mat dst, int colormap);
 void ApplyCustomColorMap(Mat src, Mat dst, Mat colormap);


### PR DESCRIPTION
Add ```WarpPerspectiveWithParams``` function in imgproc. 

It provides ability to have 
* **transparency** in borders with ```BORDER_TRANSPARENT``` [OpenCV Doc](https://docs.opencv.org/4.x/df/dc3/core_2include_2opencv2_2core_2base_8hpp.html).
* **interpolation** choice